### PR TITLE
feat: Initial Space Marines rules for 10th Edition

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -2677,12 +2677,12 @@
         </profile>
         <profile id="2863-a693-5033-2e7b" name="Refuse to Yield" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time an attack is allocated to this model, halve the Damage characteristic of that attack.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในแต่ละครั้งที่การโจมตีถูกจัดสรรมายังโมเดลนี้, ให้หารครึ่งค่า Damage ของการโจมตีนั้น</characteristic>
           </characteristics>
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="65ac-314e-ef32-fc12">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
 
 ■ Aggressor Squad
 ■ Eradicator Squad
@@ -3147,12 +3147,12 @@
       <profiles>
         <profile name="Master of Deceit" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" id="2d39-4b7-eecd-9111">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">After both players have deployed their armies, if your army includes one or more models with this ability, you can select up to three friendly ADEPTUS ASTARTES INFANTRY units and redeploy all of those units. When doing so, any of those units can be placed into Strategic Reserves, regardless of how many units are already in Strategic Reserves.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">หลังจากที่ผู้เล่นทั้งสองฝ่ายได้วางยูนิตในกองทัพของตนเสร็จแล้ว, ถ้ากองทัพของคุณมียูนิตหนึ่งยูนิตหรือมากกว่าที่มีความสามารถนี้, คุณสามารถเลือกยูนิตที่เป็นมิตร ADEPTUS ASTARTES INFANTRY ได้สูงสุดสามยูนิตและทำการ redeploy ยูนิตทั้งหมดเหล่านั้น เมื่อทำเช่นนั้น, ยูนิตใดๆ ในกลุ่มนั้นสามารถถูกนำไปไว้ใน Strategic Reserves ได้, โดยไม่คำนึงว่ามียูนิตอยู่ใน Strategic Reserves อยู่แล้วกี่ยูนิต</characteristic>
           </characteristics>
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="707b-cbab-54ac-96eb">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
 
 ■ Eliminator Squad
 ■ Incursor Squad
@@ -3450,7 +3450,7 @@
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="c0ec-c5a8-757a-a31c">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
 
 ■ Relic Terminator Squad
 ■ Terminator Assault Squad
@@ -3459,7 +3459,7 @@
         </profile>
         <profile name="Unstoppable Valour" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="131c-1105-d301-f6f9">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">You can re-roll Charge rolls made for this model’s unit.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">คุณสามารถ re-roll Charge rolls สำหรับยูนิตของโมเดลนี้ได้</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3668,12 +3668,12 @@
         </profile>
         <profile name="Angel&apos;s Wrath" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="b7b7-62a5-211-3f1c">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, each time that unit ends a Charge move, until the end of the turn, add 1 to the Strength characteristic of melee  weapons equipped by models in that unit.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้กำลังเป็นผู้นำยูนิต, ในแต่ละครั้งที่ยูนิตนั้นจบการ Charge move, จนกระทั่งจบเทิร์น, ให้บวก 1 ให้กับค่า Strength ของอาวุธประชิดที่โมเดลในยูนิตนั้นติดตั้งอยู่</characteristic>
           </characteristics>
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="7bc3-a914-c28c-84d5">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
 
 ■ Assault Intercessors with Jump Packs
 ■ Vanguard Veteran Squad with Jump Packs</characteristic>
@@ -4790,7 +4790,7 @@
       <profiles>
         <profile name="Shock Assault" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="f80a-70bd-e9d-3452">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a model in this unit targets an enemy unit with a melee attack, re-roll a Wound roll of 1. If that enemy unit is within range of an objective marker, you can re-roll the Wound roll instead.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในแต่ละครั้งที่โมเดลในยูนิตนี้เล็งเป้าหมายไปยังยูนิตศัตรูด้วยการโจมตีระยะประชิด, ให้ re-roll a Wound roll ที่ออก 1. ถ้ายูนิตศัตรูนั้นอยู่ในระยะของ an objective marker, คุณสามารถ re-roll the Wound roll แทนได้</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7495,10 +7495,11 @@ Strategic Reserves.</characteristic>
       <profiles>
         <profile name="Bladeguard" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="13f1-27da-509b-815f">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">At the start of the Fight phase, you can select one of the following abilities to apply to models in this unit until the end of the phase:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในตอนเริ่มต้นของ Fight phase, คุณสามารถเลือกหนึ่งในความสามารถต่อไปนี้เพื่อใช้กับโมเดลในยูนิตนี้จนกระทั่งจบเฟส:
 
-■ Swords of the Imperium: Each time a model in this unit makes a melee attack, re-roll a Hit roll of 1.
-■ Shields of the Imperium: Each time an invulnerable saving throw is made for a model in this unit, re-roll a saving throw of 1.</characteristic>
+
+■ Swords of the Imperium: ในแต่ละครั้งที่โมเดลในยูนิตนี้ทำการโจมตีระยะประชิด, re-roll a Hit roll ที่ออก 1.
+■ Shields of the Imperium: ในแต่ละครั้งที่ทำการทอย invulnerable saving throw ให้กับโมเดลในยูนิตนี้, re-roll a saving throw ที่ออก 1.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -12987,7 +12988,7 @@ bearer can be moved during that move</characteristic>
         </profile>
         <profile name="Brutalis Charge" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="dbd0-636-26e-2482">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model ends a Charge move, select one enemy unit within Engagement Range of it and roll one D6: on a 2-3, that enemy unit suffers D3 mortal wounds; on a 4-5, that enemy unit suffers 3 mortal wounds; on a 6, that enemy unit suffers D3+3 mortal wounds</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในแต่ละครั้งที่โมเดลนี้จบการ Charge move, เลือกหนึ่งยูนิตศัตรูที่อยู่ใน Engagement Range ของมันและทอยเต๋า D6 หนึ่งลูก: หากได้ 2-3, ยูนิตศัตรูนั้นได้รับความเสียหาย D3 mortal wounds; หากได้ 4-5, ยูนิตศัตรูนั้นได้รับความเสียหาย 3 mortal wounds; หากได้ 6, ยูนิตศัตรูนั้นได้รับความเสียหาย D3+3 mortal wounds</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -13574,7 +13575,8 @@ bearer can be moved during that move</characteristic>
       <profiles>
         <profile name="Chainsword Doctrines" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="e865-1963-3fc1-1d05">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this unit is selected to fight, select one of the following abilities to apply to all Astartes chainswords equipped by models in this unit until the end of the phase: 
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในแต่ละครั้งที่ยูนิตนี้ถูกเลือกให้ต่อสู้, เลือกหนึ่งในความสามารถต่อไปนี้เพื่อใช้กับ Astartes chainswords ทั้งหมดที่โมเดลในยูนิตนี้ติดตั้งอยู่จนกระทั่งจบเฟส:
+
 
 ■ [SUSTAINED HITS 1]
 ■ [LETHAL HITS]
@@ -14003,7 +14005,7 @@ bearer can be moved during that move</characteristic>
       <profiles>
         <profile name="Hammer of Wrath" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="6cd4-7f02-68da-a69a">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this unit ends a Charge move, select one enemy unit within Engagement Range of it and roll one D6 for each model in this unit: for each 4+, that enemy unit suffers 1 mortal wound.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในแต่ละครั้งที่ยูนิตนี้จบการ Charge move, เลือกหนึ่งยูนิตศัตรูที่อยู่ใน Engagement Range ของมัน, จากนั้นทอยเต๋า D6 หนึ่งลูกสำหรับแต่ละโมเดลในยูนิตนี้: สำหรับแต่ละผลลัพธ์ที่ได้ 4+, ยูนิตศัตรูนั้นได้รับความเสียหาย 1 mortal wound</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -14618,7 +14620,7 @@ bearer can be moved during that move</characteristic>
       <profiles>
         <profile name="Outrider Escort" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="6542-61e5-432c-b5bf">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per turn, in your opponent’s Shooting phase, when a friendly ^^Adeptus Astartes Mounted^^ unit within 6&quot; of this model is selected as the target of an attack, this model can use this ability. If it does, after that enemy unit has finished making its attacks, this model can shoot as if it were your Shooting phase, but when resolving those attacks it can only target that enemy unit (and only if it is an eligible target).</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">หนึ่งครั้งต่อเทิร์น, ใน Shooting phase ของฝ่ายตรงข้าม, เมื่อยูนิตที่เป็นมิตร ^^Adeptus Astartes Mounted^^ ที่อยู่ในระยะ 6&quot; จากโมเดลนี้ถูกเลือกเป็นเป้าหมายของการโจมตี, โมเดลนี้สามารถใช้ความสามารถนี้ได้ หากทำเช่นนั้น, หลังจากที่ยูนิตศัตรูนั้นทำการโจมตีเสร็จสิ้นแล้ว, โมเดลนี้สามารถยิงได้เสมือนว่าเป็น Shooting phase ของคุณ, แต่เมื่อทำการโจมตีเหล่านั้น มันจะสามารถเล็งเป้าหมายได้เฉพาะยูนิตศัตรูนั้นเท่านั้น (และจะทำได้ก็ต่อเมื่อยูนิตนั้นยังเป็นเป้าหมายที่ยิงได้)</characteristic>
           </characteristics>
           <modifiers>
             <modifier type="set" value="true" field="hidden">
@@ -14754,7 +14756,7 @@ bearer can be moved during that move</characteristic>
       <profiles>
         <profile name="Turbo Boost" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="adc4-9ea6-9780-7adc">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this unit Advances, do not make an Advance roll for it. Instead, until the end of the phase, add 6&quot; to the Move characteristic of models in this unit</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในแต่ละครั้งที่ยูนิตนี้ทำการ Advance, ไม่ต้องทอยเต๋า Advance roll. แต่ให้บวก 6&quot; เข้ากับค่า Move ของโมเดลในยูนิตนี้แทนจนกระทั่งจบเฟส</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -24078,12 +24080,12 @@ Normal move. If it does so, until the end of the turn, this unit is not eligible
         </profile>
         <profile name="Swift Assault" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="c18-38-db11-f42b">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, ranged weapons equipped by models in that unit have the [ASSAULT] ability.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้กำลังเป็นผู้นำยูนิต, อาวุธระยะไกล ที่โมเดลในยูนิตนั้นติดตั้งอยู่จะได้รับความสามารถ [ASSAULT]</characteristic>
           </characteristics>
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="b91a-9570-fe75-f836">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
 
 ■ Bike Squad
 ■ Outrider Squad</characteristic>
@@ -27221,7 +27223,7 @@ Attacks characteristic of 7.</characteristic>
       <profiles>
         <profile name="Mindlock" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="70c9-5565-956-5984">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While a Techmarine model is leading this unit, improve the Ballistic Skill and Weapon Skill characteristics of ranged and melee weapons equipped by  Astartes Servitor models in this unit by 1.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดล Techmarine กำลังเป็นผู้นำยูนิตนี้, ให้เพิ่มค่า Ballistic Skill และ Weapon Skill ของ อาวุธระยะไกล และอาวุธประชิดที่โมเดล Astartes Servitor ในยูนิตนี้ติดตั้งอยู่ขึ้น 1</characteristic>
           </characteristics>
         </profile>
         <profile name="Invulnerable Save" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="a7d9-b59d-c183-5a32">
@@ -27231,7 +27233,7 @@ Attacks characteristic of 7.</characteristic>
         </profile>
         <profile name="Servitor Retinue" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="fc8b-f27a-abcb-b24d">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">At the start of the Declare Battle Formations step, this unit can join one other unit from your army that is being led by a Techmarine. If it does, until the end of the battle, every model in this unit counts as being part of that Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased accordingly.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในตอนเริ่มต้นของ Declare Battle Formations step, ยูนิตนี้สามารถเข้าร่วมกับยูนิตอื่นอีกหนึ่งยูนิตจากกองทัพของคุณซึ่งถูกนำโดย Techmarine ได้ หากทำเช่นนั้น, จนกระทั่งจบเกม, ทุกโมเดลในยูนิตนี้จะนับว่าเป็นส่วนหนึ่งของยูนิต Bodyguard นั้น, และค่า Starting Strength ของยูนิต Bodyguard นั้นจะถูกเพิ่มขึ้นตามนั้น</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -27866,17 +27868,17 @@ Attacks characteristic of 7.</characteristic>
         </profile>
         <profile name="Narthecium" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="1b7d-5cf9-f91f-3938">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, in your Command phase, you can return 1 destroyed model (excluding Character models) to that unit.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้กำลังเป็นผู้นำยูนิต, ใน Command phase ของคุณ, คุณสามารถนำโมเดล Bodyguard 1 ตัวที่ถูกทำลายไปแล้ว (ไม่รวมโมเดล CHARACTER) กลับคืนสู่ยูนิตนั้นได้</characteristic>
           </characteristics>
         </profile>
         <profile name="Gene Seed Recovery" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="1826-b313-9e4f-57c">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">When this model’s Bodyguard unit is destroyed, roll one D6: on a 2+, you gain 1CP.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">เมื่อยูนิต Bodyguard ของโมเดลนี้ถูกทำลาย, ให้ทอยเต๋า D6 หนึ่งลูก: หากได้ 2+, คุณจะได้รับ 1CP</characteristic>
           </characteristics>
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="a19-ea12-9d03-65c4">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
 
 ■ Assault Intercessor Squad
 ■ Desolation Squad
@@ -27887,7 +27889,7 @@ Attacks characteristic of 7.</characteristic>
 ■ Sternguard Veteran Squad
 ■ Tactical Squad
 
-You can attach this model to one of the above units even if one Captain, Chapter Master or Lieutenant model has already been attached to it. If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.</characteristic>
+คุณสามารถให้โมเดลนี้เข้าร่วมกับหนึ่งในยูนิตข้างต้นได้ แม้ว่าในยูนิตนั้นจะมีโมเดล Captain, Chapter Master หรือ Lieutenant หนึ่งตัวเข้าร่วมอยู่แล้วก็ตาม หากคุณทำเช่นนั้น, และยูนิต Bodyguard นั้นถูกทำลาย, ยูนิต Leader ที่เข้าร่วมอยู่จะกลายเป็นยูนิตแยก, พร้อมกับค่า Starting Strength เดิมของพวกมัน</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -28093,23 +28095,23 @@ You can attach this model to one of the above units even if one Captain, Chapte
         </profile>
         <profile name="Surgical Precision" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="a06d-1a78-a0e3-8b0d">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, weapons equipped by models in that unit have the [LETHAL HITS] ability.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้กำลังเป็นผู้นำยูนิต, อาวุธที่โมเดลในยูนิตนั้นติดตั้งอยู่จะได้รับความสามารถ [LETHAL HITS]</characteristic>
           </characteristics>
         </profile>
         <profile name="Vivispectrum" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="739f-7ad5-5b0f-cd36">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">If this model’s unit destroys an enemy unit as the result of a melee attack, until the end of the battle, this model has an Objective Control characteristic of 9.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ถ้ายูนิตของโมเดลนี้ทำลายยูนิตศัตรูอันเป็นผลมาจากการโจมตีระยะประชิด, จนกระทั่งจบเกม, โมเดลนี้จะมีค่า Objective Control เท่ากับ 9</characteristic>
           </characteristics>
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="90f4-f4cf-7e9-2088">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
 
 ■ Aggressor Squad
 ■ Eradicator Squad
 ■ Heavy Intercessor Squad
 
-You can attach this model to one of the above units even if one Captain or Chapter Master model has already been attached to it. If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.</characteristic>
+คุณสามารถให้โมเดลนี้เข้าร่วมกับหนึ่งในยูนิตข้างต้นได้ แม้ว่าในยูนิตนั้นจะมีโมเดล Captain หรือ Chapter Master หนึ่งตัวเข้าร่วมอยู่แล้วก็ตาม หากคุณทำเช่นนั้น, และยูนิต Bodyguard นั้นถูกทำลาย, ยูนิต Leader ที่เข้าร่วมอยู่จะกลายเป็นยูนิตแยก, พร้อมกับค่า Starting Strength เดิมของพวกมัน</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -28512,16 +28514,17 @@ You can attach this model to one of the above units even if one Captain, Chapte
         </profile>
         <profile name="Deeds of Heroism" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="80e9-b186-e4ce-2ae5">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle, when this model is selected to fight, it can use this ability. If it does, until the end of the phase, add 1 to the Attacks characteristic of melee weapons equipped by models in this model’s unit</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">หนึ่งครั้งต่อเกม, เมื่อโมเดลนี้ถูกเลือกให้ต่อสู้, เขาสามารถใช้ความสามารถนี้ได้ หากทำเช่นนั้น, จนกระทั่งจบเฟส, ให้บวก 1 ให้กับค่า Attacks ของอาวุธประชิดที่โมเดลต่างๆ ในยูนิตของโมเดลนี้ติดตั้งอยู่</characteristic>
           </characteristics>
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="16d0-eff3-f5d2-a2cf">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following unit:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
+
 
 ■ Bladeguard Veteran Squad
 
-You can attach this model to the above unit even if one Captain, Chapter Master or Lieutenant model has already been attached to it. If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.</characteristic>
+คุณสามารถให้โมเดลนี้เข้าร่วมกับยูนิตข้างต้นได้ แม้ว่าในยูนิตนั้นจะมีโมเดล Captain, Chapter Master หรือ Lieutenant หนึ่งตัวเข้าร่วมอยู่แล้วก็ตาม หากคุณทำเช่นนั้น, และยูนิต Bodyguard นั้นถูกทำลาย, ยูนิต Leader ที่เข้าร่วมอยู่จะกลายเป็นยูนิตแยก, พร้อมกับค่า Starting Strength เดิมของพวกมัน</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -28688,17 +28691,18 @@ You can attach this model to the above unit even if one Captain, Chapter Master
         </profile>
         <profile name="Keep the Banner High" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="15d8-f178-3876-42f5">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, each time a model in that unit makes an attack, add 1 to the Hit roll if that unit is below its Starting Strength, and add 1 to the Wound roll as well if that unit is Below Half-strength</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้กำลังเป็นผู้นำยูนิต, ในแต่ละครั้งที่โมเดลในยูนิตนั้นทำการโจมตี, ให้บวก 1 ให้กับค่า Hit roll ถ้ายูนิตนั้นมีจำนวนโมเดล ต่ำกว่าจำนวนเริ่มต้น, และบวก 1 ให้กับค่า Wound roll ด้วยถ้ายูนิตนั้นมีจำนวนโมเดล ต่ำกว่าครึ่งหนึ่ง</characteristic>
           </characteristics>
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="ab49-936e-921e-b30b">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
+
 
 ■ Terminator Squad
 ■ Terminator Assault Squad
 
-You can attach this model to one of the above units even if one Captain, Chapter Master or Lieutenant model has already been attached to it. If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.</characteristic>
+คุณสามารถให้โมเดลนี้เข้าร่วมกับหนึ่งในยูนิตข้างต้นได้ แม้ว่าในยูนิตนั้นจะมีโมเดล Captain, Chapter Master หรือ Lieutenant หนึ่งตัวเข้าร่วมอยู่แล้วก็ตาม หากคุณทำเช่นนั้น, และยูนิต Bodyguard นั้นถูกทำลาย, ยูนิต Leader ที่เข้าร่วมอยู่จะกลายเป็นยูนิตแยก, พร้อมกับค่า Starting Strength เดิมของพวกมัน</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -29816,7 +29820,8 @@ You can attach this model to one of the above units even if one Captain, Chapte
         </profile>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="6e66-2c98-4726-d12d">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
+
 
 ■ Assault Intercessor Squad
 ■ Bladeguard Veteran Squad*
@@ -29827,7 +29832,7 @@ You can attach this model to one of the above units even if one Captain, Chapte
 ■ Company Heroes
 ■ Tactical Squad
 
-* This model cannot be attached to a Bladeguard Veteran Squad unless it is equipped with a relic shield, and cannot be attached to a Hellblaster Squad unless it is equipped with a plasma pistol.</characteristic>
+* โมเดลนี้ไม่สามารถเข้าร่วมกับ Bladeguard Veteran Squad ได้เว้นแต่มันจะติดตั้ง relic shield, และไม่สามารถเข้าร่วมกับ Hellblaster Squad ได้เว้นแต่มันจะติดตั้ง plasma pistol</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -30227,12 +30232,12 @@ You can attach this model to one of the above units even if one Captain, Chapte
         </profile>
         <profile name="Suppression Fire" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="b05-d2dc-4dd4-81ee">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Shooting phase, after this model has shot, select one enemy unit hit by one or more attacks made with its twin macro-accelerator cannon this phase. Until the start of your next turn, while this model is on the battlefield, that enemy unit is suppressed. While a unit is suppressed, each time a model in that unit makes an attack, subtract 1 from the Hit roll.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ใน Shooting phase ของคุณ, หลังจากที่โมเดลนี้ได้ยิงไปแล้ว, เลือกหนึ่งยูนิตศัตรูที่ถูกโจมตีโดนด้วยการโจมตีหนึ่งครั้งหรือมากกว่าจาก twin macro-accelerator cannon ของมันในเฟสนี้ จนกระทั่งถึงตอนเริ่มต้นของเทิร์นถัดไปของคุณ, ตราบใดที่โมเดลนี้ยังอยู่ในสนามรบ, ยูนิตศัตรูนั้นจะติดสถานะ suppressed (ถูกกดดัน) ตราบใดที่ยูนิตติดสถานะ suppressed, ในแต่ละครั้งที่โมเดลในยูนิตนั้นทำการโจมตี, ให้ลบ 1 ออกจาก Hit roll</characteristic>
           </characteristics>
         </profile>
         <profile name="Invulnerable Save" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="9622-e60b-c2fe-dd8f">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model has a 5+ invulnerable save against ranged attacks.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้มี 5+ invulnerable save ต่อการโจมตีด้วย อาวุธระยะไกล</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -32315,12 +32320,12 @@ You can attach this model to one of the above units even if one Captain, Chapte
         </profile>
         <profile name="Transport" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="6943-fbd0-f8ec-a693">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model has a transport capacity of 12 Adeptus Astartes Infantry models. Each Jump Pack, Wulfen, Gravis or Terminator model takes up the space of 2 models and each Centurion model takes up the space of 3 models.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้มีความจุในการขนส่ง (Transport Capacity) 12 โมเดลที่เป็น Adeptus Astartes Infantry โมเดลแต่ละตัวที่มี Jump Pack, Wulfen, Gravis หรือ Terminator จะใช้พื้นที่เท่ากับ 2 โมเดล และโมเดล Centurion แต่ละตัวจะใช้พื้นที่เท่ากับ 3 โมเดล</characteristic>
           </characteristics>
         </profile>
         <profile name="Into the Foe" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="58cc-7fec-e711-e00d">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">If a unit disembarks from this Transport before it moves, until the end of the turn, that unit is eligible to charge in a turn in which it Advanced.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ถ้ายูนิตลงจาก Transport นี้ก่อนที่มันจะเคลื่อนที่, จนกระทั่งจบเทิร์น, ยูนิตนั้นจะสามารถทำการ charge ได้ในเทิร์นที่มันได้ทำการ Advanced</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -34908,7 +34913,8 @@ You can attach this model to one of the above units even if one Character model
       <profiles>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="bb08-858e-9634-9515">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
+
 
 ■ Bike Squad
 ■ Outrider Squad</characteristic>
@@ -34916,7 +34922,7 @@ You can attach this model to one of the above units even if one Character model
         </profile>
         <profile name="Unbreakable Duty" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="57ab-cc79-bce4-f9ff">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is within range of an objective marker and/or within 6&quot; of the centre of the battlefield, this model has the Feel No Pain 4+ ability.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้อยู่ในระยะของ an objective marker และ/หรือ อยู่ในระยะ 6&quot; of the centre of the battlefield, โมเดลนี้จะได้รับความสามารถ Feel No Pain 4+</characteristic>
           </characteristics>
         </profile>
         <profile name="Ancient on Bike [Legends]" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="487a-244c-1db9-dc53">
@@ -35258,7 +35264,7 @@ You can attach this model to one of the above units even if one Character model
       <profiles>
         <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="e17-41e5-b31-1d44">
           <characteristics>
-            <characteristic name="Description" id="5081-e5ed-db29-c5af" hidden="false" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">โมเดลนี้สามารถเข้าร่วมกับยูนิตต่อไปนี้ได้:
 
 ■ Bike Squad
 ■ Outrider Squad</characteristic>
@@ -35266,12 +35272,12 @@ You can attach this model to one of the above units even if one Character model
         </profile>
         <profile name="Gene Seed Recovery" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="64b0-83c0-a1db-1ee8">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">When this model’s Bodyguard unit is destroyed, roll one D6: on a 2+, you gain 1CP.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">เมื่อยูนิต Bodyguard ของโมเดลนี้ถูกทำลาย, ให้ทอยเต๋า D6 หนึ่งลูก: หากได้ 2+, คุณจะได้รับ 1CP</characteristic>
           </characteristics>
         </profile>
         <profile name="Narthecium" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="7782-ca5-3b11-d45d">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, in your Command phase, you can return 1 destroyed model (excluding Character models) to that unit.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้กำลังเป็นผู้นำยูนิต, ใน Command phase ของคุณ, คุณสามารถนำโมเดล Bodyguard 1 ตัวที่ถูกทำลายไปแล้ว (ไม่รวมโมเดล CHARACTER) กลับคืนสู่ยูนิตนั้นได้</characteristic>
           </characteristics>
         </profile>
         <profile name="Apothecary on Bike [Legends]" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="7b61-654c-f18c-183c">
@@ -36662,7 +36668,7 @@ per turn.</characteristic>
       <profiles>
         <profile name="Hammer of Wrath" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="1df-b883-26cb-3084">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this unit ends a Charge move, select one enemy unit within Engagement Range of it, then roll one D6 for each model in this unit that is within Engagement Range of that enemy unit: for each 4+, that enemy unit suffers 1 mortal wound.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ในแต่ละครั้งที่ยูนิตนี้จบการ Charge move, เลือกหนึ่งยูนิตศัตรูที่อยู่ใน Engagement Range ของมัน, จากนั้นทอยเต๋า D6 หนึ่งลูกสำหรับแต่ละโมเดลในยูนิตนี้ที่อยู่ใน Engagement Range ของยูนิตศัตรูนั้น: สำหรับแต่ละผลลัพธ์ที่ได้ 4+, ยูนิตศัตรูนั้นได้รับความเสียหาย 1 mortal wound</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -37491,12 +37497,12 @@ per turn.</characteristic>
   <sharedProfiles>
     <profile id="90c7-c55c-21e2-2232" name="Rites of Battle" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle round, one unit from your army with this ability can use it when its unit is targeted with a Stratagem. If it does, reduce the CP cost of that use of that Stratagem by 1CP.</characteristic>
+        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">หนึ่งครั้งต่อ battle round, หนึ่งยูนิตจากกองทัพของคุณที่มีความสามารถนี้สามารถใช้มันได้เมื่อยูนิตของมันถูกเล็งเป้าหมายด้วย Stratagem หากทำเช่นนั้น, ให้ลดค่า CP ของการใช้ Stratagem ครั้งนั้นลง 1CP</characteristic>
       </characteristics>
     </profile>
     <profile id="fdf1-64a5-906c-3474" name="Finest Hour" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle, at the start of the Fight phase, this model can use this ability. If it does, until the end of the phase, add 3 to the Attacks characteristic of melee weapons equipped by this model and those weapons have the [DEVASTATING WOUNDS] ability.</characteristic>
+        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">หนึ่งครั้งต่อเกม, ในตอนเริ่มต้นของ Fight phase, โมเดลนี้สามารถใช้ความสามารถนี้ได้ หากทำเช่นนั้น, จนกระทั่งจบเฟส, ให้บวก 3 ให้กับค่า Attacks ของอาวุธประชิดที่โมเดลนี้ติดตั้งอยู่ และอาวุธเหล่านั้นจะได้รับความสามารถ [DEVASTATING WOUNDS]</characteristic>
       </characteristics>
     </profile>
     <profile name="Psychic Hood" hidden="false" id="116b-b23c-4ea4-30ed" typeName="Abilities" typeId="9cc3-6d83-4dd3-9b64">
@@ -37522,7 +37528,7 @@ per turn.</characteristic>
     </profile>
     <profile name="Damaged: 1-4 Wounds Remaining" hidden="false" id="ee64-aaaf-75df-8da9" typeName="Abilities" typeId="9cc3-6d83-4dd3-9b64">
       <characteristics>
-        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้เหลือ 1-4 wounds, ในแต่ละครั้งที่โมเดลนี้ทำการโจมตี, ให้ลบ 1 ออกจาก Hit roll</characteristic>
       </characteristics>
     </profile>
     <profile name="Damaged: 1-5 Wounds Remaining" hidden="false" id="1aac-b083-4318-f750" typeName="Abilities" typeId="9cc3-6d83-4dd3-9b64">

--- a/Imperium - Ultramarines.cat
+++ b/Imperium - Ultramarines.cat
@@ -45,7 +45,7 @@
       <profiles>
         <profile name="Lead From the Front" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="5553-620a-d5da-ecb1">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, models in that unit have the Scouts 6&quot; ability and ranged weapons equipped by models in that unit have the [ASSAULT] ability.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้กำลังเป็นผู้นำยูนิต, โมเดลในยูนิตนั้นจะได้รับความสามารถ Scouts 6&quot; และอาวุธยิง (Ranged Weapons) ที่โมเดลในยูนิตนั้นติดตั้งอยู่จะได้รับความสามารถ [ASSAULT]</characteristic>
           </characteristics>
         </profile>
         <profile name="Captain Sicarius" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="aeb4-b4da-9ad8-5d91">

--- a/Imperium - Ultramarines.cat
+++ b/Imperium - Ultramarines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="4029-9237-e8db-af55" name="Imperium - Adeptus Astartes - Ultramarines" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="29" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="4029-9237-e8db-af55" name="Imperium - Adeptus Astartes - Ultramarines" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="30" battleScribeVersion="2.03" type="catalogue" authorName="snoykiwi">
   <entryLinks>
     <entryLink import="true" name="Captain Sicarius" hidden="false" type="selectionEntry" id="7740-af66-ac4f-68b6" targetId="2ae8-40ec-ba34-dfe5"/>
     <entryLink import="true" name="Chaplain Cassius [Legends]" hidden="false" type="selectionEntry" id="e1e-1c6b-bb62-f9c8" targetId="b180-3cac-9124-b818"/>

--- a/Library - Astartes Heresy Legends.cat
+++ b/Library - Astartes Heresy Legends.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ac3b-689c-4ad4-70cb" name="Library - Astartes Heresy Legends" revision="8" battleScribeVersion="2.03" library="true" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ac3b-689c-4ad4-70cb" name="Library - Astartes Heresy Legends" revision="9" battleScribeVersion="2.03" library="true" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
   <categoryEntries>
     <categoryEntry id="39b9-56da-6787-1880" name="Kratos" hidden="false">
       <constraints>
@@ -6146,7 +6146,7 @@
   <sharedProfiles>
     <profile id="8edb-b088-4c26-2fef" name="Damaged: 1-6 wounds remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-6 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">ตราบใดที่โมเดลนี้เหลือ 1-6 wounds, ในแต่ละครั้งที่โมเดลนี้ทำการโจมตี, ให้ลบ 1 ออกจาก Hit roll</characteristic>
       </characteristics>
     </profile>
     <profile id="d44e-2f5-cadf-9eb" name="Damaged: 1-4 wounds remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">

--- a/Warhammer 40,000.gst
+++ b/Warhammer 40,000.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-352e-adc2-7639-d6a9" name="Warhammer 40,000 10th Edition - TH Version" revision="42" battleScribeVersion="2.03" type="gameSystem">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-352e-adc2-7639-d6a9" name="Warhammer 40,000 10th Edition - TH Version" revision="42" battleScribeVersion="2.03" type="gameSystem" authorName="snoykiwi x 3xbun">
   <publications>
     <publication id="48fc-15aa-b307-9443" name="10th Edition Core Rules" shortName="10th Ed Core"/>
     <publication name="Github" hidden="false" id="8db3-575d-91b-47f8" shortName="BSData/wh40k-10e" publisherUrl="https://github.com/BSData/wh40k-10e"/>
@@ -843,130 +843,142 @@
   </sharedSelectionEntries>
   <sharedRules>
     <rule id="8bf7-8812-923d-29e4" name="Pistol" publicationId="48fc-15aa-b307-9443" page="25" hidden="false">
-      <description>Weapons with [PISTOL] in their profile are known as Pistols. If a unit contains any models equipped with Pistols, that unit is eligible to shoot in its controlling player’s Shooting phase even while it is within Engagement Range of one or more enemy units. When such a unit is selected to shoot, it can only resolve attacks using its Pistols and can only target one of the enemy units it is within Engagement Range of. In such circumstances, a Pistol can target an enemy unit even if other friendly units are within Engagement Range of the same enemy unit. 
+      <description>อาวุธที่มี [PISTOL] ในโปรไฟล์จะถูกเรียกว่า Pistols (ปืนพก) ถ้ายูนิตมียูนิตใดๆ ที่ติดตั้ง Pistols, ยูนิตนั้นจะยังคงสามารถยิงได้ใน Shooting phase ของผู้เล่นที่ควบคุม แม้ว่าจะอยู่ใน Engagement Range ของยูนิตศัตรูหนึ่งยูนิตหรือมากกว่าก็ตาม เมื่อยูนิตดังกล่าวถูกเลือกให้ยิง, มันจะสามารถทำการโจมตีได้โดยใช้ Pistols ของมันเท่านั้น และจะสามารถเล็งเป้าหมายได้เพียงหนึ่งยูนิตจากยูนิตศัตรูที่มันอยู่ใน Engagement Range ด้วยเท่านั้น ในสถานการณ์เช่นนี้, Pistol สามารถเล็งเป้าหมายไปยังยูนิตศัตรูได้แม้ว่ายูนิตอื่นฝ่ายเราจะอยู่ใน Engagement Range ของยูนิตศัตรูเดียวกันนั้นก็ตาม
 
-If a model is equipped with one or more Pistols, unless it is a MONSTER or VEHICLE model, it can either shoot with its Pistols or with all of its other ranged weapons. Declare whether such a model will shoot with its Pistols or its other ranged weapons before selecting targets.</description>
+
+ถ้าโมเดลติดตั้ง Pistols หนึ่งกระบอกหรือมากกว่า, เว้นแต่มันจะเป็นโมเดล MONSTER หรือ VEHICLE, มันจะสามารถเลือกได้ว่าจะยิงด้วย Pistols ของมัน หรือจะยิงด้วย อาวุธระยะไกล อื่นๆ ทั้งหมดของมัน ให้ประกาศว่าโมเดลดังกล่าวจะยิงด้วย Pistols หรือ อาวุธระยะไกล อื่นๆ ก่อนที่จะเลือกเป้าหมาย</description>
     </rule>
     <rule id="8367-374c-f87-c627" name="Hazardous" publicationId="48fc-15aa-b307-9443" page="28" hidden="false">
-      <description>Weapons with [HAZARDOUS] in their profile are known as Hazardous weapons. Each time a unit is selected to shoot or fight, after that unit has resolved all of its attacks, for each Hazardous weapon that targets were selected for when resolving those attacks, that unit must take one Hazardous test. To do so, roll one D6: on a 1, that test is failed. For each failed test you must resolve the following sequence (resolve each failed test one at a time): 
+      <description>อาวุธที่มี [HAZARDOUS] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Hazardous ในแต่ละครั้งที่ยูนิตถูกเลือกให้ยิงหรือต่อสู้, หลังจากที่ยูนิตนั้นทำการโจมตีทั้งหมดเสร็จสิ้นแล้ว, สำหรับอาวุธ Hazardous แต่ละชิ้นที่ได้ถูกเลือกเป้าหมายให้เมื่อทำการโจมตีเหล่านั้น, ยูนิตนั้นจะต้องทำการทดสอบ Hazardous หนึ่งครั้ง โดยการทอยเต๋า D6 หนึ่งลูก: หากได้ผลเป็น 1, การทดสอบนั้นจะล้มเหลว สำหรับการทดสอบที่ล้มเหลวแต่ละครั้ง คุณจะต้องทำตามลำดับต่อไปนี้ (ให้คิดผลการทดสอบที่ล้มเหลวทีละครั้ง):
 
-■ If possible, select one model in that unit that has lost one or more wounds and is equipped with one or more Hazardous weapons. 
-■ Otherwise, if possible, select one model in that unit (excluding CHARACTER models) equipped with one or more Hazardous weapons. 
-■ Otherwise, select one CHARACTER model in that unit equipped with one or more Hazardous weapons. 
 
-If a model was selected, that unit suffers 3 mortal wounds and when allocating those mortal wounds, they must be allocated to the selected model. 
+■ ถ้าเป็นไปได้, เลือกโมเดล 1 ตัวในยูนิตนั้นที่เสียพลังชีวิตไปแล้วหนึ่งหน่วยหรือมากกว่าและติดตั้งอาวุธ Hazardous หนึ่งชิ้นหรือมากกว่า. 
+■ มิฉะนั้น, ถ้าเป็นไปได้, เลือกโมเดล 1 ตัวในยูนิตนั้น (ไม่รวมโมเดล CHARACTER) ที่ติดตั้งอาวุธ Hazardous หนึ่งชิ้นหรือมากกว่า
+■ มิฉะนั้น, เลือกโมเดล CHARACTER 1 ตัวในยูนิตนั้นที่ติดตั้งอาวุธ Hazardous หนึ่งชิ้นหรือมากกว่า
 
-If a unit from a player’s army is selected as the target of the Fire Overwatch Stratagem in their opponent’s Charge phase, any mortal wounds inflicted by Hazardous tests are allocated after the charging unit has ended its Charge move.</description>
+
+ถ้ามีโมเดลถูกเลือก, ยูนิตนั้นจะได้รับ 3 mortal wounds และเมื่อจัดสรร mortal wounds เหล่านั้น, จะต้องจัดสรรให้กับโมเดลที่ถูกเลือก
+
+
+ถ้ายูนิตจากกองทัพของผู้เล่นถูกเลือกเป็นเป้าหมายของ Stratagem Fire Overwatch ใน Charge phase ของฝ่ายตรงข้าม, mortal wounds ใดๆ ที่เกิดจากการทดสอบ Hazardous จะถูกจัดสรรหลังจากที่ยูนิตที่ชาร์จเข้ามาได้เคลื่อนที่จบแล้ว</description>
     </rule>
     <rule id="b4dd-3e1f-41cb-218f" name="Leader" publicationId="48fc-15aa-b307-9443" page="39" hidden="false">
-      <description>While a Bodyguard unit contains a Leader, it is known as an Attached unit and, with the exception of rules that are triggered when units are destroyed (pg 12), it is treated as a single unit for all rules purposes. Each time an attack targets an Attached unit, until the attacking unit has resolved all of its attacks, you must use the Toughness characteristic of the Bodyguard models in that unit, even if a Leader in that unit has a different Toughness characteristic. Each time an attack successfully wounds an Attached unit, that attack cannot be allocated to a Character model in that unit, even if that Character model has lost one or more wounds or has already had attacks allocated to it this phase. As soon as the last Bodyguard model in an Attached unit has been destroyed, any attacks made against that unit that have yet to be allocated can then be allocated to Character models in that unit.
+      <description>ตราบใดที่ยูนิต Bodyguard มียูนิต Leader อยู่ข้างใน, มันจะถูกเรียกว่ายูนิต Attached และ, ยกเว้นกฎที่ทำงานเมื่อยูนิตถูกทำลาย (หน้า 12), มันจะถูกนับว่าเป็นยูนิตเดียวสำหรับทุกจุดประสงค์ของกฎ ในแต่ละครั้งที่การโจมตีเล็งเป้าหมายมายังยูนิต Attached, จนกว่ายูนิตที่โจมตีจะคิดผลการโจมตีทั้งหมดเสร็จสิ้น, คุณจะต้องใช้ค่า Toughness ของโมเดล Bodyguard ในยูนิตนั้น, แม้ว่า Leader ในยูนิตนั้นจะมีค่า Toughness ที่แตกต่างออกไปก็ตาม ในแต่ละครั้งที่การโจมตีทำ Wound ใส่ยูนิต Attached ได้สำเร็จ, การโจมตีนั้นจะไม่สามารถถูกจัดสรรไปยังโมเดล Character ในยูนิตนั้นได้, แม้ว่าโมเดล Character นั้นจะเคยเสียพลังชีวิตไปแล้วหนึ่งหน่วยหรือมากกว่า หรือเคยได้รับการจัดสรรการโจมตีไปแล้วในเฟสนี้ก็ตาม ทันทีที่โมเดล Bodyguard ตัวสุดท้ายในยูนิต Attached ถูกทำลาย, การโจมตีใดๆ ที่ทำใส่ยูนิตนั้นซึ่งยังไม่ได้ถูกจัดสรรจะสามารถถูกจัดสรรไปยังโมเดล Character ในยูนิตนั้นได้
 
-Each time the last model in a Bodyguard unit is destroyed, each CHARACTER unit that is part of that Attached unit becomes a separate unit, with its original Starting Strength. If this happens as the result of an attack, they become separate units after the attacking unit has resolved all of its attacks. 
 
-Each time the last model in a CHARACTER unit that is attached to a Bodyguard unit is destroyed and there is not another CHARACTER unit attached, that Attached unit’s Bodyguard unit becomes a separate unit, with its original Starting Strength. If this happens as the result of an attack, they become separate units after the attacking unit has resolved all of its attacks. 
+ในแต่ละครั้งที่โมเดลตัวสุดท้ายในยูนิต Bodyguard ถูกทำลาย, ยูนิต CHARACTER แต่ละยูนิตที่เป็นส่วนหนึ่งของยูนิต Attached นั้นจะกลายเป็นยูนิตแยก, พร้อมกับค่า Starting Strength เดิมของมัน ถ้าสิ่งนี้เกิดขึ้นจากผลของการโจมตี, พวกเขาจะกลายเป็นยูนิตแยกหลังจากที่ยูนิตที่โจมตีได้คิดผลการโจมตีทั้งหมดเสร็จสิ้นแล้ว
 
-Each time a unit that is part of an Attached unit is destroyed, it does not have the keywords of any other units that make up that Attached unit (unless it has those keywords on its own datasheet) for the purposes of any rules that would be triggered when that unit is destroyed.</description>
+
+ในแต่ละครั้งที่โมเดลตัวสุดท้ายในยูนิต CHARACTER ที่เข้าร่วมกับยูนิต Bodyguard ถูกทำลาย และไม่มียูนิต CHARACTER อื่นเข้าร่วมอยู่, ยูนิต Bodyguard ของยูนิต Attached นั้นจะกลายเป็นยูนิตแยก, พร้อมกับค่า Starting Strength เดิมของมัน ถ้าสิ่งนี้เกิดขึ้นจากผลของการโจมตี, พวกเขาจะกลายเป็นยูนิตแยกหลังจากที่ยูนิตที่โจมตีได้คิดผลการโจมตีทั้งหมดเสร็จสิ้นแล้ว
+
+
+ในแต่ละครั้งที่ยูนิตที่เป็นส่วนหนึ่งของยูนิต Attached ถูกทำลาย, มันจะไม่มีคีย์เวิร์ดของยูนิตอื่นใดที่ประกอบกันเป็นยูนิต Attached นั้น (เว้นแต่มันจะมีคีย์เวิร์ดเหล่านั้นอยู่บน datasheet ของตัวเอง) สำหรับจุดประสงค์ของกฎใดๆ ที่จะทำงานเมื่อยูนิตนั้นถูกทำลาย</description>
     </rule>
     <rule id="be1e-ac8e-1e2c-3528" name="Devastating Wounds" publicationId="48fc-15aa-b307-9443" page="28" hidden="false">
-      <description>Weapons with [DEVASTATING WOUNDS] in their profile are known as Devastating Wounds weapons. Each time an attack is made with such a weapon, if that attack scores a Critical Wound, no saving throw of any kind can be made against that attack (including invulnerable saving throws). Such attacks are only allocated to models after all other attacks made by the attacking unit have been allocated and resolved. After that attack is allocated and after any modifiers are applied, it inflicts a number of mortal wounds on the target equal to the Damage characteristic of that attack, instead of inflicting damage normally.</description>
+      <description>อาวุธที่มี [DEVASTATING WOUNDS] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Devastating Wounds ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้, ถ้าการโจมตีนั้นทำ Critical Wound ได้สำเร็จ, จะไม่สามารถทำการทอย saving throw ชนิดใดๆ ก็ตามเพื่อป้องกันการโจมตีนั้นได้ (รวมถึง invulnerable saving throws) การโจมตีดังกล่าวจะถูกจัดสรรไปยังโมเดลเป้าหมายหลังจากที่การโจมตีอื่นๆ ทั้งหมดของยูนิตที่ทำการโจมตีได้ถูกจัดสรรและคิดผลไปแล้วเท่านั้น หลังจากที่การโจมตีนั้นถูกจัดสรรและหลังจากปรับค่าใดๆ แล้ว, มันจะสร้าง Mortal Wounds แก่เป้าหมายเป็นจำนวนเท่ากับค่า Damage ของการโจมตีนั้น, แทนที่จะสร้างความเสียหายตามปกติ</description>
     </rule>
     <rule id="fc8a-8c24-bae9-cc1c" name="Assault" publicationId="48fc-15aa-b307-9443" page="25" hidden="false">
-      <description>Weapons with [ASSAULT] in their profile are known as Assault weapons. If a unit that Advanced this turn contains any models equipped with Assault weapons, it is still eligible to shoot in this turn’s Shooting phase. When such a unit is selected to shoot, you can only resolve attacks using Assault weapons its models are equipped with.</description>
+      <description>อาวุธที่มี [ASSAULT] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Assault ถ้ายูนิตที่ได้ทำการ Advance ในเทิร์นนี้มีโมเดลที่ติดตั้งอาวุธ Assault อยู่, ยูนิตนั้นจะยังคงสามารถยิงได้ใน Shooting phase ของเทิร์นนี้ เมื่อยูนิตดังกล่าวถูกเลือกให้ยิง, คุณจะสามารถทำการโจมตีได้โดยใช้อาวุธ Assault ที่โมเดลในยูนิตนั้นติดตั้งอยู่เท่านั้น</description>
     </rule>
     <rule id="115b-79dc-f723-d761" name="Extra Attacks" publicationId="48fc-15aa-b307-9443" page="28" hidden="false">
-      <description>Weapons with [EXTRA ATTACKS] in their profile are known as Extra Attacks weapons. Each time the bearer of one or more Extra Attacks weapons fights, it makes attacks with each of the Extra Attacks melee weapons it is equipped with and it makes attacks with one of the melee weapons it is equipped with that does not have the [EXTRA ATTACKS] ability (if any). The number of attacks made with an Extra Attacks weapon cannot be modified by other rules, unless that weapon’s name is explicitly specified in that rule.</description>
+      <description>อาวุธที่มี [EXTRA ATTACKS] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Extra Attacks ในแต่ละครั้งที่ผู้ถืออาวุธ Extra Attacks หนึ่งชิ้นหรือมากกว่าทำการต่อสู้, มันจะทำการโจมตีด้วยอาวุธประชิด Extra Attacks แต่ละชิ้นที่มันติดตั้งอยู่ และมันจะทำการโจมตีด้วยอาวุธประชิดหนึ่งชิ้นที่มันติดตั้งอยู่ซึ่งไม่มีความสามารถ [EXTRA ATTACKS] (ถ้ามี) จำนวนการโจมตีที่ทำด้วยอาวุธ Extra Attacks จะไม่สามารถถูกปรับค่าได้โดยกฎอื่น, เว้นแต่ชื่อของอาวุธนั้นจะถูกระบุไว้อย่างชัดเจนในกฎนั้น</description>
     </rule>
     <rule id="cf93-ad4d-2f08-a79d" name="Twin-linked" publicationId="48fc-15aa-b307-9443" page="25" hidden="false">
-      <description>Weapons with [TWIN-LINKED] in their profile are known as Twin-linked weapons. Each time an attack is made with such a weapon, you can re-roll that attack’s Wound roll.</description>
+      <description>อาวุธที่มี [TWIN-LINKED] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Twin-linked ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้, คุณสามารถ re-roll Wound roll ของการโจมตีนั้นได้</description>
     </rule>
     <rule id="4111-82e3-9444-e942" name="Anti-" publicationId="48fc-15aa-b307-9443" page="28" hidden="false">
-      <description>Weapons with [ANTI-KEYWORD X+] in their profile are known as Anti weapons. Each time an attack is made with such a weapon against a target with the keyword after the word ‘Anti-’, an unmodified Wound roll of ‘x+’ scores a Critical Wound.</description>
+      <description>อาวุธที่มี [ANTI-KEYWORD X+] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Anti ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้ไปยังเป้าหมายที่มีคีย์เวิร์ดตรงกับคำที่อยู่หลัง &apos;Anti-&apos;, ผลการทอย Wound roll แบบยังไม่ปรับค่า (Unmodified) ที่ได้ &apos;x+&apos; จะถือว่าเป็น Critical Wound</description>
     </rule>
     <rule id="1897-c22c-9597-12b1" name="Sustained Hits" publicationId="48fc-15aa-b307-9443" page="28" hidden="false">
-      <description>Weapons with [SUSTAINED HITS X] in their profile are known as Sustained Hits weapons. Each time an attack is made with such a weapon, if a Critical Hit is rolled, that attack scores a number of additional hits on the target as denoted by ‘x’</description>
+      <description>อาวุธที่มี [SUSTAINED HITS X] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Sustained Hits ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้, ถ้าทอยได้ Critical Hit, การโจมตีนั้นจะสร้าง การโจมตีเพิ่มเติม ใส่เป้าหมายเป็นจำนวนเท่ากับที่ระบุไว้ด้วย ‘x’</description>
     </rule>
     <rule id="1202-10a8-78e9-4c67" name="Heavy" publicationId="48fc-15aa-b307-9443" page="26" hidden="false">
-      <description>Weapons with [HEAVY] in their profile are known as Heavy weapons. Each time an attack is made with such a weapon, if the attacking model’s unit Remained Stationary this turn, add 1 to that attack’s Hit roll.</description>
+      <description>อาวุธที่มี [HEAVY] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Heavy ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้, ถ้ายูนิตของโมเดลที่ทำการโจมตีได้ Remained Stationary (หยุดนิ่งอยู่กับที่) ในเทิร์นนี้, ให้บวก 1 เข้ากับ Hit roll ของการโจมตีนั้น</description>
     </rule>
     <rule id="7cdb-fb99-44a9-8849" name="Melta" publicationId="48fc-15aa-b307-9443" page="26" hidden="false">
-      <description>Weapons with [MELTA X] in their profile are known as Melta weapons. Each time an attack made with such a weapon targets a unit within half that weapon’s range, that attack’s Damage characteristic is increased by the amount denoted by ‘x’.</description>
+      <description>อาวุธที่มี [MELTA X] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Melta ในแต่ละครั้งที่การโจมตีที่ทำด้วยอาวุธประเภทนี้เล็งเป้าหมายไปยังยูนิตที่อยู่ในระยะครึ่งหนึ่งของระยะยิงของอาวุธนั้น, ค่า Damage ของการโจมตีนั้นจะถูกเพิ่มขึ้นตามจำนวนที่ระบุไว้ด้วย &apos;x&apos;</description>
     </rule>
     <rule id="9bf4-280f-bbe2-6fbb" name="Feel No Pain" publicationId="48fc-15aa-b307-9443" page="23" hidden="false">
-      <description>Some models have &apos;Feel No Pain x+&apos; listed in their abilities. Each time a model with this ability suffers damage and so would lose a wound (including wounds lost due to mortal wounds), roll one D6: if the result is greater than or equal to the number denoted by &apos;x: that wound is ignored and is not lost. If a model has more than one Feel No Pain ability, you can only use one of those abilities each time that model suffers damage and so would lose a wound.</description>
+      <description>โมเดลบางตัวมีความสามารถ &apos;Feel No Pain x+&apos; อยู่ในรายการอบิลิตี้ของมัน ในแต่ละครั้งที่โมเดลที่มีความสามารถนี้ได้รับดาเมจและกำลังจะเสีย wound (รวมถึง wound ที่เสียไปจาก mortal wounds), ให้ทอยเต๋า D6 หนึ่งลูก: ถ้าผลลัพธ์ที่ได้มีค่าเท่ากับหรือสูงกว่าตัวเลขที่ระบุไว้ด้วย &apos;x&apos;, wound นั้นจะถูกเมินและไม่สูญเสียไป ถ้ายูนิตมี Feel No Pain มากกว่าหนึ่งอย่าง, คุณจะสามารถใช้ได้เพียงหนึ่งความสามารถเท่านั้นในแต่ละครั้งที่โมเดลนั้นได้รับดาเมจและกำลังจะเสียพลังชีวิต</description>
     </rule>
     <rule id="6c1f-1cf7-ff25-c99e" name="Blast" publicationId="48fc-15aa-b307-9443" page="26" hidden="false">
-      <description>Weapons with [BLAST] in their profile are known as Blast weapons, and they make a random number of attacks. Each time you determine how many attacks are made with a Blast weapon, add 1 to the result for every five models that were in the target unit when you selected it as the target (rounding down). Blast weapons can never be used to make attacks against a unit that is within Engagement Range of one or more units from the attacking model’s army (including its own unit).</description>
+      <description>อาวุธที่มี [BLAST] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Blast, และมันจะทำการโจมตีเป็นจำนวนสุ่ม ในแต่ละครั้งที่คุณกำหนดจำนวนการโจมตีของอาวุธ Blast, ให้บวก 1 เข้ากับผลลัพธ์สำหรับทุกๆ ห้าโมเดลที่อยู่ในยูนิตเป้าหมาย ณ ตอนที่คุณเลือกยูนิตนั้นเป็นเป้าหมาย (ปัดเศษลง) อาวุธ Blast จะไม่สามารถใช้ทำการโจมตีใส่ยูนิตที่อยู่ใน Engagement Range ของยูนิตฝ่ายเรา (รวมถึงยูนิตของตัวเอง) ได้เลย</description>
     </rule>
     <rule id="9143-31ae-e0a6-6007" name="Precision" publicationId="48fc-15aa-b307-9443" page="26" hidden="false">
-      <description>Weapons with [PRECISION] in their profile are known as Precision weapons. Each time an attack made with such a weapon successfully wounds an Attached unit, if a Character model in that unit is visible to the attacking model, the attacking model’s player can choose to have that attack allocated to that Character model instead of following the normal attack sequence.</description>
+      <description>อาวุธที่มี [PRECISION] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Precision ในแต่ละครั้งที่การโจมตีที่ทำด้วยอาวุธประเภทนี้ทำ Wound ใส่ยูนิต Attached ได้สำเร็จ, ถ้าโมเดล Character ในยูนิตนั้นมองเห็นได้โดยโมเดลที่ทำการโจมตี, ผู้เล่นของโมเดลที่ทำการโจมตีสามารถเลือกที่จะให้การโจมตีนั้นถูกจัดสรรไปยังโมเดล Character นั้นแทนที่จะทำตามลำดับการโจมตีปกติ</description>
     </rule>
     <rule id="4ddd-4e29-acdd-5e6d" name="Indirect Fire" publicationId="48fc-15aa-b307-9443" page="26" hidden="false">
-      <description>Weapons with [INDIRECT FIRE] in their profile are known as Indirect Fire weapons, and attacks can be made with them even if the target is not visible to the attacking model. These attacks can destroy enemy models in a target unit even though none may have been visible to the attacking unit when you selected that target.
+      <description>อาวุธที่มี [INDIRECT FIRE] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Indirect Fire, และสามารถทำการโจมตีด้วยอาวุธเหล่านี้ได้แม้ว่าเป้าหมายจะมองไม่เห็นโดยโมเดลที่ทำการโจมตี การโจมตีเหล่านี้สามารถทำลายโมเดลศัตรูในยูนิตเป้าหมายได้แม้ว่าจะไม่มีโมเดลใดเลยที่มองเห็นได้โดยยูนิตที่ทำการโจมตี ณ ตอนที่คุณเลือกเป้าหมายนั้น
 
 
-If no models in a target unit are visible to the attacking unit when you select that target, then each time a model in the attacking unit makes an attack against that target using an Indirect Fire weapon, subtract 1 from that attack’s Hit roll, an unmodified Hit roll of 1-3 always fails, and the target has the Benefit of Cover against that attack. Weapons with the [TORRENT] ability cannot be fired using the [INDIRECT FIRE] ability.</description>
+
+ถ้าไม่มีโมเดลใดในยูนิตเป้าหมายที่มองเห็นได้โดยยูนิตที่ทำการโจมตี ณ ตอนที่คุณเลือกเป้าหมายนั้น, ในแต่ละครั้งที่โมเดลในยูนิตที่ทำการโจมตีทำการโจมตีใส่เป้าหมายนั้นโดยใช้อาวุธ Indirect Fire, ให้ลบ 1 ออกจาก Hit roll ของการโจมตีนั้น, ผล Hit roll แบบยังไม่ปรับค่าที่ได้ 1-3 จะพลาดเสมอ, และเป้าหมายจะได้รับ Benefit of Cover ต่อการโจมตีนั้น อาวุธที่มีความสามารถ [TORRENT] จะไม่สามารถยิงโดยใช้ความสามารถ [INDIRECT FIRE] ได้</description>
     </rule>
     <rule id="2ebc-abdf-8129-6c57" name="Lance" publicationId="48fc-15aa-b307-9443" page="25" hidden="false">
-      <description>Weapons with [LANCE] in their profile are known as Lance weapons. Each time an attack is made with such a weapon, if the bearer made a Charge move this turn, add 1 to that attack’s Wound roll.</description>
+      <description>อาวุธที่มี [LANCE] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Lance ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้, ถ้าผู้ถืออาวุธได้ทำการ Charge move ในเทิร์นนี้, ให้บวก 1 เข้ากับ Wound roll ของการโจมตีนั้น</description>
     </rule>
     <rule id="d1d1-611e-5191-1095" name="Lethal Hits" publicationId="48fc-15aa-b307-9443" page="25" hidden="false">
-      <description>Weapons with [LETHAL HITS] in their profile are known as Lethal Hits weapons. Each time an attack is made with such a weapon, a Critical Hit automatically wounds the target.</description>
+      <description>อาวุธที่มี [LETHAL HITS] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Lethal Hits ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้, Critical Hit จะทำ Wound ใส่เป้าหมายโดยอัตโนมัติ</description>
     </rule>
     <rule id="4640-43e7-30b-215a" name="Ignores Cover" publicationId="48fc-15aa-b307-9443" page="25" hidden="false">
-      <description>Weapons with [IGNORES COVER] in their profile are known as Ignores Cover weapons. Each time an attack is made with such a weapon, the target cannot have the Benefit of Cover against that attack.</description>
+      <description>อาวุธที่มี [IGNORES COVER] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Ignores Cover ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้, เป้าหมายจะไม่สามารถรับประโยชน์จากที่กำบัง (Benefit of Cover) ต่อการโจมตีนั้นได้</description>
     </rule>
     <rule id="c5c8-8b58-b8b6-7786" name="Rapid Fire" publicationId="48fc-15aa-b307-9443" page="25" hidden="false">
-      <description>Weapons with [RAPID FIRE X] in their profile are known as Rapid Fire weapons. Each time such a weapon targets a unit within half that weapon’s range, the Attacks characteristic of that weapon is increased by the amount denoted by ‘x’.</description>
+      <description>อาวุธที่มี [RAPID FIRE X] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Rapid Fire ในแต่ละครั้งที่อาวุธประเภทนี้เล็งเป้าหมายไปยังยูนิตที่อยู่ในระยะครึ่งหนึ่งของระยะยิงของอาวุธนั้น, ค่า Attacks ของอาวุธนั้นจะถูกเพิ่มขึ้นตามจำนวนที่ระบุไว้ด้วย &apos;x&apos;</description>
     </rule>
     <rule id="5edf-d619-23e0-9b56" name="Torrent" publicationId="48fc-15aa-b307-9443" page="25" hidden="false">
-      <description>Weapons with [TORRENT] in their profile are known as Torrent weapons. Each time an attack is made with such a weapon, that attack automatically hits the target.</description>
+      <description>อาวุธที่มี [TORRENT] ในโปรไฟล์จะถูกเรียกว่าอาวุธ Torrent ในแต่ละครั้งที่ทำการโจมตีด้วยอาวุธประเภทนี้, การโจมตีนั้นจะโดนเป้าหมายโดยอัตโนมัติ</description>
     </rule>
     <rule id="ada6-bac1-ffe0-d6f7" name="Scouts" publicationId="48fc-15aa-b307-9443" page="39" hidden="false">
-      <description>Some units have ‘Scouts x&quot;’ listed in their abilities. If every model in a unit has this ability, then at the start of the first battle round, before the first turn begins, it can make a Normal move of up to x&quot;, with the exception that, while making that move, the distance moved by each model in that unit can be greater than that model&apos;s Move characteristic, as long as it is not greater than x&quot;. 
+      <description>ยูนิตบางยูนิตมีความสามารถ ‘Scouts x&quot;’ อยู่ในรายการอบิลิตี้ของมัน ถ้าทุกโมเดลในยูนิตมีความสามารถนี้, ในตอนเริ่มต้นของ battle round แรก, ก่อนที่เทิร์นแรกจะเริ่มต้นขึ้น, มันสามารถทำการ Normal move ได้ไกลสูงสุด x&quot;, โดยมีข้อยกเว้นว่า, ในขณะที่ทำการเคลื่อนที่นั้น, ระยะทางที่เคลื่อนที่โดยแต่ละโมเดลในยูนิตนั้นสามารถมากกว่าค่า Move ของโมเดลนั้นได้, ตราบใดที่มันไม่มากกว่า x&quot;
 
-DEDICATED TRANSPORT models can make use of any Scouts x&quot; ability listed in their abilities, or a Scouts x&quot; ability that a unit that starts the battle embarked within that DEDICATED TRANSPORT  model has (provided only models with this ability are embarked within that Dedicated Transport model), regardless of how that embarked unit gained this ability (e.g. listed in their abilities, conferred by an Enhancement or by an attached Character, etc.). 
 
-A unit that moves using this ability must end that move more than 9&quot; horizontally away from all enemy models. If both players have units that can do this, the player who is taking the first turn moves their units first.</description>
+โมเดล DEDICATED TRANSPORT สามารถใช้ความสามารถ Scouts x&quot; ใดๆ ที่ระบุในอบิลิตี้ของมัน, หรือความสามารถ Scouts x&quot; ที่ยูนิตที่เริ่มเกมโดยสารอยู่ข้างใน DEDICATED TRANSPORT นั้นมี (หากมีเพียงโมเดลที่มีความสามารถนี้เท่านั้นที่โดยสารอยู่ใน Dedicated Transport นั้น), โดยไม่คำนึงว่ายูนิตที่โดยสารนั้นได้รับความสามารถนี้มาได้อย่างไร (เช่น มีในอบิลิตี้, ได้รับจาก Enhancement หรือจาก Character ที่เข้าร่วม, เป็นต้น)
+
+
+ยูนิตที่เคลื่อนที่โดยใช้ความสามารถนี้จะต้องจบการเคลื่อนที่นั้นห่างในแนวราบมากกว่า 9&quot; จากโมเดลศัตรูทั้งหมด ถ้าผู้เล่นทั้งสองฝ่ายมียูนิตที่สามารถทำเช่นนี้ได้, ผู้เล่นที่ได้เล่นเทิร์นแรกจะได้เคลื่อนยูนิตของตนก่อน</description>
     </rule>
     <rule id="c05d-f4c3-f091-4938" name="Infiltrators" publicationId="48fc-15aa-b307-9443" page="39" hidden="false">
-      <description>During deployment, if every model in a unit has this ability, then when you set it up, it can be set up anywhere on the battlefield that is more than 9&quot; horizontally away from the enemy deployment zone and all enemy models.</description>
+      <description>ในช่วง Deployment, ถ้าทุกโมเดลในยูนิตมีความสามารถนี้, เมื่อคุณวางยูนิตนั้น, มันสามารถถูกวางที่ใดก็ได้ในสนามรบซึ่งอยู่ห่างในแนวราบมากกว่า 9&quot; จากเขตวางยูนิตของศัตรู (Enemy Deployment Zone) และจากโมเดลศัตรูทั้งหมด</description>
     </rule>
     <rule id="7cb5-dd6b-dd87-ad3b" name="Deep Strike" publicationId="48fc-15aa-b307-9443" page="39" hidden="false">
-      <description>During the Declare Battle Formations step, if every model in a unit has this ability, you can set it up in Reserves instead of setting it up on the battlefield. If you do, in the Reinforcements step of one of your Movement phases you can set up this unit anywhere on the battlefield that is more than 9&quot; horizontally away from all enemy models.
+      <description>ในช่วง Declare Battle Formations step, ถ้าทุกโมเดลในยูนิตมีความสามารถนี้, คุณสามารถวางยูนิตนั้นไว้ใน Reserves แทนที่จะวางในสนามรบได้ หากคุณทำเช่นนั้น, ในช่วง Reinforcements step ของ Movement phase ของคุณ, คุณสามารถนำยูนิตนี้มาวางที่ใดก็ได้ในสนามรบซึ่งอยู่ห่างในแนวราบมากกว่า 9&quot; จากโมเดลศัตรูทั้งหมด
 
-If a unit with the Deep Strike ability arrives from Strategic Reserves, the controlling player can choose for that unit to be set up either using the rules for Strategic Reserves or using the Deep Strike ability.</description>
+
+ถ้ายูนิตที่มีความสามารถ Deep Strike มาจาก Strategic Reserves, ผู้เล่นที่ควบคุมยูนิตนั้นสามารถเลือกได้ว่าจะให้ยูนิตนั้นถูกวางในสนามโดยใช้กฎของ Strategic Reserves หรือใช้ความสามารถ Deep Strike</description>
     </rule>
     <rule id="b68a-5ded-65ac-98c" name="Deadly Demise" publicationId="48fc-15aa-b307-9443" page="23" hidden="false">
-      <description>Some models have &apos;Deadly Demise x&apos; listed in their abilities. When such a model is destroyed, roll one D6 before removing it from play (if such a model is a TRANSPORT, roll before any embarked models disembark). On a 6, each unit within 6&quot; of that model suffers a number of mortal wounds denoted by &apos;x&apos; (if this is a random number, roll separately for each unit within 6&quot;).</description>
+      <description>โมเดลบางตัวมีความสามารถ &apos;Deadly Demise x&apos; อยู่ในรายการอบิลิตี้ของมัน เมื่อโมเดลดังกล่าวถูกทำลาย, ให้ทอยเต๋า D6 หนึ่งลูกก่อนที่จะนำโมเดลนั้นออกจากสนาม (ถ้าโมเดลนั้นเป็น TRANSPORT, ให้ทอยเต๋าก่อนที่โมเดลที่โดยสารอยู่จะลงจากรถ) หากทอยได้ 6, แต่ละยูนิตที่อยู่ในระยะ 6&quot; จากโมเดลนั้นจะได้รับ Mortal Wounds เป็นจำนวนเท่ากับค่า &apos;x&apos; (ถ้าค่า x เป็นตัวเลขสุ่ม, ให้ทอยเต๋าแยกกันสำหรับแต่ละยูนิตที่อยู่ในระยะ 6&quot;)</description>
     </rule>
     <rule id="bec5-4288-34a6-ccfa" name="Stealth" publicationId="48fc-15aa-b307-9443" page="20" hidden="false">
-      <description>If every model in a unit has this ability, then each time a ranged attack is made against it, subtract 1 from that attack’s Hit roll.</description>
+      <description>ถ้าทุกโมเดลในยูนิตมีความสามารถนี้, ในแต่ละครั้งที่การโจมตีด้วย อาวุธระยะไกล ถูกทำใส่ยูนิตนั้น, ให้ลบ 1 ออกจาก Hit roll ของการโจมตีนั้น</description>
     </rule>
     <rule id="5e13-1624-d280-418d" name="Super-Heavy Walker" hidden="false">
-      <description>Each time a model with this ability makes a Normal, Advance or Fall Back move, it can move through models (excluding TITANIC models) and sections of terrain features that are 4&quot; or less in height. 
-When doing so:
-- It can move within Engagement Range of enemy models, but cannot end that move within Engagement Range of them.
-- It can also move through sections of terrain features that are more than 4&quot; in height, but if it does, after it has moved, roll one D6: on a 1, that model is Battle-shocked.</description>
+      <description>ในแต่ละครั้งที่โมเดลที่มีความสามารถนี้ทำการ Normal, Advance หรือ Fall Back move, มันสามารถเคลื่อนที่ทะลุโมเดล (ไม่รวมโมเดล TITANIC) และส่วนของ terrain features ที่มีความสูง 4&quot; หรือน้อยกว่าได้
+เมื่อทำเช่นนั้น:
+- มันสามารถเคลื่อนที่เข้าไปใน Engagement Range ของโมเดลศัตรูได้, แต่ไม่สามารถจบการเคลื่อนที่นั้นใน Engagement Range ของพวกมันได้
+- มันยังสามารถเคลื่อนที่ทะลุส่วนของ terrain features ที่มีความสูงมากกว่า 4&quot; ได้ด้วย, แต่ถ้าทำเช่นนั้น, หลังจากที่มันเคลื่อนที่เสร็จแล้ว, ให้ทอยเต๋า D6 หนึ่งลูก: หากได้ 1, โมเดลนั้นจะติด Battle-shocked</description>
     </rule>
     <rule id="a8a0-8fe7-898-e0f3" name="Lone Operative" publicationId="48fc-15aa-b307-9443" page="19" hidden="false">
-      <description>Unless part of an Attached unit, this unit can only be selected as the target of a ranged attack if the attacking model is within 12&quot;.</description>
+      <description>เว้นแต่จะเป็นส่วนหนึ่งของยูนิต Attached, ยูนิตนี้จะสามารถถูกเลือกเป็นเป้าหมายของการโจมตีด้วยอาวุธระยะไกลได้ ก็ต่อเมื่อโมเดลที่ทำการโจมตีอยู่ในระยะ 12&quot; เท่านั้น</description>
     </rule>
     <rule id="eec5-5f54-9c03-c305" name="Hover" publicationId="48fc-15aa-b307-9443" page="53" hidden="false">
-      <description>Some AIRCRAFT models have &apos;Hover&apos; listed in their abilities. When you are instructed to Declare Battle Formations, before doing anything else, you must first declare which models from your army with this ability will be in Hover mode.
+      <description>โมเดล AIRCRAFT บางตัวมีความสามารถ &apos;Hover&apos; อยู่ในรายการอบิลิตี้ของมัน เมื่อคุณได้รับคำสั่งให้ Declare Battle Formations, ก่อนที่จะทำสิ่งอื่นใด, คุณจะต้องประกาศก่อนว่าโมเดลใดจากกองทัพของคุณที่มีความสามารถนี้จะเข้าสู่โหมด Hover
 
-If a model is in Hover mode,  then until the end of the battle, its Move characteristic is changed to 20&quot;, it loses the AIRCRAFT keyword and it loses all associated rules for being an AlRCRAFT model. Models in Hover mode do not start the battle in Reserves, but you can choose to place them into Strategic Reserves following the normal rules if you wish.</description>
+
+ถ้าโมเดลอยู่ในโหมด Hover, จนกระทั่งจบเกม, ค่า Move ของมันจะเปลี่ยนเป็น 20&quot;, มันจะสูญเสียคีย์เวิร์ด AIRCRAFT และสูญเสียกฎทั้งหมดที่เกี่ยวข้องกับการเป็นโมเดล AIRCRAFT โมเดลในโหมด Hover จะไม่เริ่มเกมใน Reserves, แต่คุณสามารถเลือกที่จะนำพวกมันไปไว้ใน Strategic Reserves ตามกฎปกติได้หากต้องการ</description>
     </rule>
     <rule id="24-c886-e8ba-5a89" name="Fights First" publicationId="48fc-15aa-b307-9443" page="32" hidden="false">
-      <description>Units with this ability that are eligible to fight do so in the Fights First step, provided every model in the unit has this ability.</description>
+      <description>ยูนิตที่มีความสามารถนี้ซึ่งมีสิทธิ์ในการต่อสู้ จะได้ทำการต่อสู้ในช่วง Fights First step, หากทุกโมเดลในยูนิตนั้นมีความสามารถนี้</description>
     </rule>
     <rule id="e9c4-2bb8-12ee-cd1b" name="Psychic" publicationId="48fc-15aa-b307-9443" page="38" hidden="false">
-      <description>Some weapons and abilities can only be used by PSYKERS. Such weapons and abilities are tagged with the word &apos;Psychic&apos;. If a Psychic weapon or ability causes any unit to suffer one or more wounds, each of those wounds is considered to have been inflicted by a Psychic Attack.</description>
+      <description>อาวุธและความสามารถบางอย่างสามารถใช้ได้โดย PSYKERS เท่านั้น อาวุธและความสามารถดังกล่าวจะถูกกำกับด้วยคำว่า &apos;Psychic&apos; ถ้าอาวุธหรือความสามารถ Psychic ทำให้ยูนิตใดๆ เสียหนึ่ง wound หรือมากกว่า, wound แต่ละครั้งเหล่านั้นจะถูกนับว่าเกิดจากการโจมตีด้วยพลังจิต (Psychic Attack)</description>
     </rule>
     <rule id="13b2-6518-dab3-7ea1" name="Firing Deck" page="17" hidden="false">
-      <description>Some TRANSPORT models have ‘Firing Deck x’ listed in their abilities. Each time such a model is selected to shoot in the Shooting phase, you can select up to ‘x’ models embarked within it whose units have not already shot this phase. Then, for each of those embarked models, you can select one ranged weapon that embarked model is equipped with (excluding weapons with the [ONE SHOT] ability). Until that TRANSPORT model has resolved all of its attacks, it counts as being equipped with all of the weapons you selected in this way, in addition to its other weapons. Until the end of the phase, those selected models’ units are not eligible to shoot.</description>
+      <description>โมเดล TRANSPORT บางตัวมีความสามารถ &apos;Firing Deck x&apos; อยู่ในรายการอบิลิตี้ของมัน ในแต่ละครั้งที่โมเดลดังกล่าวถูกเลือกให้ยิงใน Shooting phase, คุณสามารถเลือกโมเดลที่โดยสารอยู่ข้างในได้สูงสุด &apos;x&apos; ตัวซึ่งยูนิตของโมเดลเหล่านั้นยังไม่ได้ยิงในเฟสนี้ จากนั้น, สำหรับแต่ละโมเดลที่ถูกเลือก, คุณสามารถเลือก อาวุธระยะไกล หนึ่งชิ้นที่โมเดลนั้นติดตั้งอยู่ (ไม่รวมอาวุธที่มีความสามารถ [ONE SHOT]) จนกว่าโมเดล TRANSPORT นั้นจะทำการโจมตีทั้งหมดเสร็จสิ้น, มันจะนับว่าตัวเองติดตั้งอาวุธทั้งหมดที่คุณได้เลือกด้วยวิธีนี้, เพิ่มเติมจากอาวุธอื่นๆ ของมัน จนกระทั่งจบเฟส, ยูนิตของโมเดลที่ถูกเลือกเหล่านั้นจะไม่มีสิทธิ์ยิง</description>
     </rule>
     <rule id="cd26-1611-860a-91e4" name="One Shot" hidden="false">
-      <description>The bearer can only shoot with this weapon once per battle.</description>
+      <description>ผู้ถืออาวุธนี้จะสามารถยิงด้วยอาวุธนี้ได้เพียงครั้งเดียวต่อเกม (Once per battle)</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Adds translated rules for a variety of Adeptus Astartes units, including many HQ and infantry units, for Warhammer 40,000 10th Edition.